### PR TITLE
Make python pre-commit hook fail if it would reformat

### DIFF
--- a/lint.sh
+++ b/lint.sh
@@ -16,6 +16,6 @@ fi
 EXCLUDE_RE='.venv|venv|build|granulate_utils/generated'
 
 python3 -m isort --settings-path .isort.cfg $check_arg --skip granulate_utils/generated --skip venv --skip .venv --skip build .
-python3 -m black --line-length 120 $check_arg --exclude $EXCLUDE_RE .
+python3 -m black --check --diff --color --line-length 120 $check_arg --exclude $EXCLUDE_RE .
 python3 -m flake8 --config .flake8  --exclude $(echo $EXCLUDE_RE | tr '|' ',') .
 python3 -m mypy --exclude $EXCLUDE_RE .


### PR DESCRIPTION
Currently, when I run `git commit` with a staged file that would be reformatted by the pre-commit hook, the hook will reformat the file but the the commit succeed with the unforamtted staged files.

I'd like to make the pre-commit hook fail if it would reformat the file, so that I can fix the formatting and then commit.